### PR TITLE
Flexcan fixes + Latest updates

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -5,3 +5,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: arduino/arduino-lint-action@v1
+        with:
+          library-manager: update
+          project-type: library

--- a/src/can_address_claim_state_machine.cpp
+++ b/src/can_address_claim_state_machine.cpp
@@ -44,6 +44,17 @@ namespace isobus
 		return m_currentState;
 	}
 
+	void AddressClaimStateMachine::on_address_violation()
+	{
+		if (State::AddressClaimingComplete == get_current_state())
+		{
+			CANStackLogger::warn("[AC]: Address violation for address %u",
+			                     get_claimed_address());
+
+			set_current_state(State::SendReclaimAddressOnRequest);
+		}
+	}
+
 	void AddressClaimStateMachine::process_commanded_address(std::uint8_t commandedAddress)
 	{
 		if (State::AddressClaimingComplete == get_current_state())

--- a/src/can_address_claim_state_machine.hpp
+++ b/src/can_address_claim_state_machine.hpp
@@ -56,6 +56,11 @@ namespace isobus
 		/// @returns The current state of the state machine
 		State get_current_state() const;
 
+		/// @brief Used to inform the address claim state machine that two CFs are using the same source address.
+		/// This function may cause the state machine to emit an address claim depending on its state, as is
+		/// required by ISO11783-5.
+		void on_address_violation();
+
 		/// @brief Attempts to process a commanded address.
 		/// @details If the state machine has claimed successfully before,
 		/// this will attempt to move a NAME from the claimed address to the new, specified address.

--- a/src/can_extended_transport_protocol.cpp
+++ b/src/can_extended_transport_protocol.cpp
@@ -295,7 +295,7 @@ namespace isobus
 					    (StateMachineState::RxDataSession == tempSession->state) &&
 					    (messageData[SEQUENCE_NUMBER_DATA_INDEX] == (tempSession->lastPacketNumber + 1)))
 					{
-						for (std::uint8_t i = SEQUENCE_NUMBER_DATA_INDEX; (i < PROTOCOL_BYTES_PER_FRAME) && ((PROTOCOL_BYTES_PER_FRAME * tempSession->lastPacketNumber) + i < tempSession->get_message_data_length()); i++)
+						for (std::uint8_t i = SEQUENCE_NUMBER_DATA_INDEX; (i < PROTOCOL_BYTES_PER_FRAME) && (((PROTOCOL_BYTES_PER_FRAME * tempSession->processedPacketsThisSession) + i) < tempSession->get_message_data_length()); i++)
 						{
 							std::uint32_t currentDataIndex = (PROTOCOL_BYTES_PER_FRAME * tempSession->processedPacketsThisSession) + i;
 							tempSession->sessionMessage.set_data(messageData[1 + SEQUENCE_NUMBER_DATA_INDEX + i], currentDataIndex);

--- a/src/can_internal_control_function.cpp
+++ b/src/can_internal_control_function.cpp
@@ -42,6 +42,11 @@ namespace isobus
 		return ControlFunction::destroy(expectedRefCount);
 	}
 
+	void InternalControlFunction::on_address_violation(CANLibBadge<CANNetworkManager>)
+	{
+		stateMachine.on_address_violation();
+	}
+
 	void InternalControlFunction::process_commanded_address(std::uint8_t commandedAddress, CANLibBadge<CANNetworkManager>)
 	{
 		stateMachine.process_commanded_address(commandedAddress);

--- a/src/can_internal_control_function.hpp
+++ b/src/can_internal_control_function.hpp
@@ -51,6 +51,10 @@ namespace isobus
 		/// @param[in] CANPort The CAN channel index for this control function to use
 		InternalControlFunction(NAME desiredName, std::uint8_t preferredAddress, std::uint8_t CANPort, CANLibBadge<InternalControlFunction>);
 
+		/// @brief Used to inform the member address claim state machine that two CFs are using the same source address.
+		/// @note Address violation occurs when two CFs are using the same source address.
+		void on_address_violation(CANLibBadge<CANNetworkManager>);
+
 		/// @brief Used by the network manager to tell the ICF that the address claim state machine needs to process
 		/// a J1939 command to move address.
 		void process_commanded_address(std::uint8_t commandedAddress, CANLibBadge<CANNetworkManager>);

--- a/src/can_network_manager.hpp
+++ b/src/can_network_manager.hpp
@@ -24,6 +24,7 @@
 #include "can_network_configuration.hpp"
 #include "can_transport_protocol.hpp"
 #include "nmea2000_fast_packet_protocol.hpp"
+#include "event_dispatcher.hpp"
 
 #include <array>
 #include <deque>
@@ -175,6 +176,11 @@ namespace isobus
 		/// @returns The configuration class for this network manager
 		CANNetworkConfiguration &get_configuration();
 
+		/// @brief Returns the network manager's event dispatcher for notifying consumers whenever an
+		/// address violation occurs involving an internal control function.
+		/// @returns An event dispatcher which can be used to get notified about address violations
+		EventDispatcher<std::shared_ptr<InternalControlFunction>> &get_address_violation_event_dispatcher();
+
 	protected:
 		// Using protected region to allow protocols use of special functions from the network manager
 		friend class AddressClaimStateMachine; ///< Allows the network manager to work closely with the address claiming process
@@ -289,6 +295,13 @@ namespace isobus
 		/// @param[in] currentMessage The message to process
 		void process_any_control_function_pgn_callbacks(const CANMessage &currentMessage);
 
+		/// @brief Validates that a CAN message has not caused an address violation.
+		/// If a violation is found, the network manager will notify the affected address claim state machine
+		/// to re-claim as is required by ISO 11783-5, and will attempt to activate a DTC that is defined in ISO 11783-5.
+		/// @note Address violation occurs when two CFs are using the same source address.
+		/// @param[in] currentMessage The message to process
+		void process_can_message_for_address_violations(const CANMessage &currentMessage);
+
 		/// @brief Checks the control function state callback list to see if we need to call
 		/// a control function state callback.
 		/// @param[in] controlFunction The controlFunction whose state has changed
@@ -361,6 +374,7 @@ namespace isobus
 		std::list<ControlFunctionStateCallback> controlFunctionStateCallbacks; ///< List of all control function state callbacks
 		std::vector<ParameterGroupNumberCallbackData> globalParameterGroupNumberCallbacks; ///< A list of all global PGN callbacks
 		std::vector<ParameterGroupNumberCallbackData> anyControlFunctionParameterGroupNumberCallbacks; ///< A list of all global PGN callbacks
+		EventDispatcher<std::shared_ptr<InternalControlFunction>> addressViolationEventDispatcher; // An event dispatcher for notifying consumers about address violations
 #if !defined CAN_STACK_DISABLE_THREADS && !defined ARDUINO
 		std::mutex receiveMessageMutex; ///< A mutex for receive messages thread safety
 		std::mutex protocolPGNCallbacksMutex; ///< A mutex for PGN callback thread safety

--- a/src/flex_can_t4_plugin.cpp
+++ b/src/flex_can_t4_plugin.cpp
@@ -14,12 +14,12 @@
 namespace isobus
 {
 #if defined(__IMXRT1062__)
-	FlexCAN_T4<CAN1, RX_SIZE_256, TX_SIZE_256> FlexCANT4Plugin::can0;
-	FlexCAN_T4<CAN2, RX_SIZE_256, TX_SIZE_256> FlexCANT4Plugin::can1;
-	FlexCAN_T4<CAN3, RX_SIZE_256, TX_SIZE_256> FlexCANT4Plugin::can2;
+	FlexCAN_T4<CAN1, RX_SIZE_256, TX_SIZE_512> FlexCANT4Plugin::can0;
+	FlexCAN_T4<CAN2, RX_SIZE_256, TX_SIZE_512> FlexCANT4Plugin::can1;
+	FlexCAN_T4<CAN3, RX_SIZE_256, TX_SIZE_512> FlexCANT4Plugin::can2;
 #elif defined(__MK20DX256__) || defined(__MK64FX512__) || defined(__MK66FX1M0__)
-	FlexCAN_T4<CAN1, RX_SIZE_256, TX_SIZE_256> FlexCANT4Plugin::can0;
-	FlexCAN_T4<CAN2, RX_SIZE_256, TX_SIZE_256> FlexCANT4Plugin::can1;
+	FlexCAN_T4<CAN1, RX_SIZE_256, TX_SIZE_512> FlexCANT4Plugin::can0;
+	FlexCAN_T4<CAN2, RX_SIZE_256, TX_SIZE_512> FlexCANT4Plugin::can1;
 #endif
 
 	FlexCANT4Plugin::FlexCANT4Plugin(std::uint8_t channel) :
@@ -104,6 +104,7 @@ namespace isobus
 		message.id = canFrame.identifier;
 		message.len = canFrame.dataLength;
 		message.flags.extended = true;
+		message.seq = 1; // Try to get messages to go out sequentially...
 		memcpy(message.buf, canFrame.data, canFrame.dataLength);
 
 		if (0 == selectedChannel)

--- a/src/flex_can_t4_plugin.hpp
+++ b/src/flex_can_t4_plugin.hpp
@@ -49,12 +49,12 @@ namespace isobus
 
 	private:
 #if defined(__IMXRT1062__)
-		static FlexCAN_T4<CAN1, RX_SIZE_256, TX_SIZE_256> can0;
-		static FlexCAN_T4<CAN2, RX_SIZE_256, TX_SIZE_256> can1;
-		static FlexCAN_T4<CAN3, RX_SIZE_256, TX_SIZE_256> can2;
+		static FlexCAN_T4<CAN1, RX_SIZE_256, TX_SIZE_512> can0;
+		static FlexCAN_T4<CAN2, RX_SIZE_256, TX_SIZE_512> can1;
+		static FlexCAN_T4<CAN3, RX_SIZE_256, TX_SIZE_512> can2;
 #elif defined(__MK20DX256__) || defined(__MK64FX512__) || defined(__MK66FX1M0__)
-		static FlexCAN_T4<CAN1, RX_SIZE_256, TX_SIZE_256> can0;
-		static FlexCAN_T4<CAN2, RX_SIZE_256, TX_SIZE_256> can1;
+		static FlexCAN_T4<CAN1, RX_SIZE_256, TX_SIZE_512> can0;
+		static FlexCAN_T4<CAN2, RX_SIZE_256, TX_SIZE_512> can1;
 #endif
 		std::uint8_t selectedChannel;
 		bool isOpen = false;

--- a/src/isobus_device_descriptor_object_pool.cpp
+++ b/src/isobus_device_descriptor_object_pool.cpp
@@ -542,6 +542,7 @@ namespace isobus
 							std::string deviceElementDesignator;
 							std::uint16_t parentObject = static_cast<std::uint16_t>(static_cast<std::uint16_t>(binaryPool[9 + numberDesignatorBytes]) | (static_cast<std::uint16_t>(binaryPool[10 + numberDesignatorBytes]) << 8));
 							std::uint16_t uniqueID = static_cast<std::uint16_t>(static_cast<std::uint16_t>(binaryPool[3]) | (static_cast<std::uint16_t>(binaryPool[4]) << 8));
+							std::uint16_t elementNumber = static_cast<std::uint16_t>(binaryPool[7 + numberDesignatorBytes]) | (static_cast<std::uint16_t>(binaryPool[8 + numberDesignatorBytes]) << 8);
 							auto type = static_cast<task_controller_object::DeviceElementObject::Type>(binaryPool[5]);
 
 							for (std::uint16_t i = 0; i < numberDesignatorBytes; i++)
@@ -549,7 +550,7 @@ namespace isobus
 								deviceElementDesignator.push_back(binaryPool[7 + i]);
 							}
 
-							if (add_device_element(deviceElementDesignator, binaryPool[7 + numberDesignatorBytes], parentObject, type, uniqueID))
+							if (add_device_element(deviceElementDesignator, elementNumber, parentObject, type, uniqueID))
 							{
 								auto DETObject = std::static_pointer_cast<task_controller_object::DeviceElementObject>(get_object_by_id(uniqueID));
 
@@ -975,8 +976,8 @@ namespace isobus
 						}
 						else if (task_controller_object::ObjectTypes::DeviceValuePresentation != child->get_object_type())
 						{
-							CANStackLogger::error("[DDOP]: Object %u has a child %u with an object type that is not allowed." +
-							                        currentProcessData->get_device_value_presentation_object_id(),
+							CANStackLogger::error("[DDOP]: Object %u has a child %u with an object type that is not allowed.",
+							                      currentProcessData->get_device_value_presentation_object_id(),
 							                      child->get_object_id());
 							CANStackLogger::error("[DDOP]: A DPD object may only have DVP children.");
 							retVal = false;
@@ -1003,8 +1004,8 @@ namespace isobus
 						}
 						else if (task_controller_object::ObjectTypes::DeviceValuePresentation != child->get_object_type())
 						{
-							CANStackLogger::error("[DDOP]: Object %u has a child %u with an object type that is not allowed." +
-							                        currentProperty->get_device_value_presentation_object_id(),
+							CANStackLogger::error("[DDOP]: Object %u has a child %u with an object type that is not allowed.",
+							                      currentProperty->get_device_value_presentation_object_id(),
 							                      child->get_object_id());
 							CANStackLogger::error("[DDOP]: A DPT object may only have DVP children.");
 							retVal = false;

--- a/src/isobus_diagnostic_protocol.hpp
+++ b/src/isobus_diagnostic_protocol.hpp
@@ -391,9 +391,6 @@ namespace isobus
 		/// @returns The two bit lamp state for CAN
 		std::uint8_t convert_flash_state_to_byte(FlashState flash) const;
 
-		/// @brief A utility function that will clean up PGN registrations
-		void deregister_all_pgns();
-
 		/// @brief This is a way to find the overall lamp states to report
 		/// @details This searches the active DTC list to find if a lamp is on or off, and to find the overall flash state for that lamp.
 		/// Basically, since the lamp states are global to the CAN message, we need a way to resolve the "total" lamp state from the list.
@@ -409,6 +406,11 @@ namespace isobus
 		/// @param[out] flash How the lamp should be flashing
 		/// @param[out] lampOn If the lamp state is on for any DTC
 		void get_inactive_list_lamp_state_and_flash_state(Lamps targetLamp, FlashState &flash, bool &lampOn) const;
+
+		/// @brief A callback function used to consume address violation events and activate a DTC
+		/// as required in ISO11783-5.
+		/// @param[in] affectedControlFunction The control function affected by an address violation
+		void on_address_violation(std::shared_ptr<InternalControlFunction> affectedControlFunction);
 
 		/// @brief Sends a DM1 encoded CAN message
 		/// @returns true if the message was sent, otherwise false
@@ -488,6 +490,7 @@ namespace isobus
 		static void process_flags(std::uint32_t flag, void *parentPointer);
 
 		std::shared_ptr<InternalControlFunction> myControlFunction; ///< The internal control function that this protocol will send from
+		std::shared_ptr<void> addressViolationEventHandle; ///< Stores the handle from registering for address violation events
 		NetworkType networkType; ///< The diagnostic network type that this protocol will use
 		std::vector<DiagnosticTroubleCode> activeDTCList; ///< Keeps track of all the active DTCs
 		std::vector<DiagnosticTroubleCode> inactiveDTCList; ///< Keeps track of all the previously active DTCs


### PR DESCRIPTION
## What's New:

- Improves reliability of transmitting large ETP sessions through the FlexCAN driver (#4)
- Brings over bugfixes from the main repo for:
    - Element Number deserialization in device descriptor object pools
    - Fixes a crash when receiving some ETP sessions' final frame
    - Fixes a couple broken log statements
- Brings over a new feature from the main repo: Address violation handling

### A little about the FlexCAN issue...

When I was originally testing use of this library on Teensy with FlexCAN, I did my testing with the VT example using a terminal that only supports 16 ETP frames at a time, which hid the fact that large ETP sessions could become corrupted due to a few issues/gremlins which I will discuss below. When testing on a terminal that supported 255 frames, I could reproduce the issue in #4 

Results of my investigating:

1. I wasn't setting the `seq` flag when writing frames to FlexCAN, which could cause out of order messages to be sent.
2. Despite setting the `seq` flag, there is _definitely_ a bug either in the FlexCAN_t4 driver, or with the actual FlexCAN peripheral on the i.MX RT1060
    - Even will all mitigations enabled to ensure messages were sent using only 1 constant tx mailbox from FlexCAN_t4, I could not stop random out of order frames!
    - I went so far as to add little shims inside the driver itself to make sure our CAN stack was not at fault, and it wasn't. We are always sending frames perfectly sequentially.
    - Even editing the FlexCAN_t4 code directly to hack out all the funny business inside it with queues and mailboxes and interrupts could not fix it.
    - There's [suspicious stuff in this chip's errata](https://www.nxp.com/docs/en/errata/IMXRT1060CE_B.pdf) about FlexCAN...
    - There's some speculation on the FlexCAN_t4's GitHub page that there may be a race condition in their driver...

Long story short, there's gremlins in the CAN peripheral on the Teensy, which is very frustrating as a library developer. I have worked with _many_ ARM devices with rock-solid CAN peripherals before, and this one seems... not great.

Anyways, rant over, I think this PR will essentially "fix" the issue for nearly every use-case for our library, because it ensures that an entire ETP sessions worth of frames will fit with plenty of overhead. I tested with a terminal that supported the max ETP frame count and several other devices on the bus, and it seemed much more reliable.

### Side note

One thing I noticed the better terminal doing was if it received an ETP frame out of order, it would re-request part of the same session starting from the last good packet it received. Our library does not yet support this, but we should! I will open a ticket on the main repo to support that at some point.

Closes #4 
